### PR TITLE
Updated to include all team roadmaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,16 @@
 # 3Q2015 Roadmap
 
+## Infrastructure
 [Wiki](https://github.com/emccode/roadmap/wiki)
 
 [Milestones](https://github.com/emccode/roadmap/milestones?direction=asc&sort=due_date&state=open)
 
 [Issues by Labels](https://github.com/emccode/roadmap/labels)
+
+
+## Applications
+[Trello Board](https://trello.com/b/r3maQXx6/emc-code-applications-team-roadmap)
+
+
+## Marketing
+[EMC {code} Calender of Events](https://www.google.com/calendar/embed?src=52rlkjj3h1lsfqmi5hr0475ceg%40group.calendar.google.com&ctz=America/New_York)


### PR DESCRIPTION
this is to better suit the roadmap tab on the emccode.github.io page
